### PR TITLE
Remove IP address of provisioning NIC and instead give bridge an IP address.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,14 @@ Role Name
 
 An Ansible role to set up a machine to host a virtual undercloud for a TripleO deployment on baremetal nodes.
 
+Background
+----------
+TripleO quickstart creates two bridges named brovc and brext for external and overcloud network by default. The default network configuration resides in [tripleo-quickstart/roles/common/defaults/main.yml](https://github.com/openstack/tripleo-quickstart/blob/master/roles/common/defaults/main.yml#L85). The environment setup roles of quickstart follow template under [tripleo-quickstart/roles/environment/setup/templates/network.xml.j2](https://github.com/openstack/tripleo-quickstart/blob/master/roles/environment/setup/templates/network.xml.j2) to iterate over the variables and create libvirt network configuration xml. The external network is for management of undercloud itself from virthost, therefore nat is enabled to masquerade internal IP subnet (192.168.23.0/24 by default). The overcloud network is for overcloud nodes to communicate with undercloud, also known as provisioning network. In case of baremetal VM overcloud deployment, the overcloud nodes are deployed on same machine as undercloud and attached to overcloud network through the libvirt VM xml template under [tripleo-quickstart/roles/libvirt/setup/overcloud/templates/baremetalvm.xml.j2](https://github.com/openstack/tripleo-quickstart/blob/master/roles/libvirt/setup/overcloud/templates/baremetalvm.xml.j2#L29). However in case of baremetal overcloud deployment the overcloud network has to be extended to physical provisioning network by attaching the nic on provisioning network to bridge brovc. 
+
 Requirements
 ------------
 
-This role assumes that the host machine already has a nic on the provisioning network. The role assigns the nic an IP address.
+This role assumes that the host machine already has a nic on the provisioning network. The role plugs the nic into the bridge for overcloud network (brovc by default). 
 
 Role Variables
 --------------

--- a/README.md
+++ b/README.md
@@ -5,7 +5,32 @@ An Ansible role to set up a machine to host a virtual undercloud for a TripleO d
 
 Background
 ----------
-TripleO quickstart creates two bridges named brovc and brext for external and overcloud network by default. The default network configuration resides in [tripleo-quickstart/roles/common/defaults/main.yml](https://github.com/openstack/tripleo-quickstart/blob/master/roles/common/defaults/main.yml#L85). The environment setup roles of quickstart follow template under [tripleo-quickstart/roles/environment/setup/templates/network.xml.j2](https://github.com/openstack/tripleo-quickstart/blob/master/roles/environment/setup/templates/network.xml.j2) to iterate over the variables and create libvirt network configuration xml. The external network is for management of undercloud itself from virthost, therefore nat is enabled to masquerade internal IP subnet (192.168.23.0/24 by default). The overcloud network is for overcloud nodes to communicate with undercloud, also known as provisioning network. In case of baremetal VM overcloud deployment, the overcloud nodes are deployed on same machine as undercloud and attached to overcloud network through the libvirt VM xml template under [tripleo-quickstart/roles/libvirt/setup/overcloud/templates/baremetalvm.xml.j2](https://github.com/openstack/tripleo-quickstart/blob/master/roles/libvirt/setup/overcloud/templates/baremetalvm.xml.j2#L29). However in case of baremetal overcloud deployment the overcloud network has to be extended to physical provisioning network by attaching the nic on provisioning network to bridge brovc. 
+TripleO quickstart creates two bridges named brovc and brext for external and overcloud network by default. The default network configuration variables reside in [tripleo-quickstart/roles/common/defaults/main.yml](https://github.com/openstack/tripleo-quickstart/blob/master/roles/common/defaults/main.yml#L85). The environment setup roles of quickstart follow template under [tripleo-quickstart/roles/environment/setup/templates/network.xml.j2](https://github.com/openstack/tripleo-quickstart/blob/master/roles/environment/setup/templates/network.xml.j2) to iterate over the variables and create libvirt network configuration xml. The external network is for management of undercloud itself from virthost, therefore nat is enabled to masquerade internal IP subnet (192.168.23.0/24 by default). The overcloud network is for overcloud nodes to communicate with undercloud, also known as provisioning network. In case of baremetal VM overcloud deployment, the overcloud nodes are deployed on same machine as undercloud and attached to overcloud network through the libvirt VM xml template under [tripleo-quickstart/roles/libvirt/setup/overcloud/templates/baremetalvm.xml.j2](https://github.com/openstack/tripleo-quickstart/blob/master/roles/libvirt/setup/overcloud/templates/baremetalvm.xml.j2#L29). However, in case of baremetal overcloud deployment the overcloud network has to be extended to physical provisioning network by attaching the nic on provisioning network to bridge brovc.
+
+After the NIC is attached to bridge by this role, it becomes slave of the bridge therefore it's IP address cannot be used to connect virthost to provisioning network. Instead the bridge itself should be given an IP address, to do that default network variables should be overridden by:
+
+```
+external_network_cidr: 192.168.23.0/24
+overcloud_network_cidr: 10.0.0.0/24
+networks:
+  - name: external
+    bridge: brext
+    forward_mode: nat
+    address: "{{ external_network_cidr|nthhost(1) }}"
+    netmask: "{{ external_network_cidr|ipaddr('netmask') }}"
+    dhcp_range:
+      - "{{ external_network_cidr|nthhost(10) }}"
+      - "{{ external_network_cidr|nthhost(50) }}"
+    nat_port_range:
+      - 1024
+      - 65535
+
+  - name: overcloud
+    bridge:  brovc
+    address: "{{ overcloud_network_cidr|nthhost(1) }}"
+    netmask: "{{ overcloud_network_cidr|ipaddr('netmask') }}"
+```
+This permits the undercloud to communicate with virthost through the bridge's IP address. It also allows Ironic to communicate with virthost's hypervisor which can be used for hybrid overcloud deployment, where overcloud could be distributed between baremetal and virtual nodes at same time.   
 
 Requirements
 ------------
@@ -18,8 +43,6 @@ Role Variables
 **Note:** Make sure to include all environment file and options from your [initial Overcloud creation](https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux_OpenStack_Platform/7/html/Director_Installation_and_Usage/sect-Scaling_the_Overcloud.html)
 
 - virthost_provisioning_interface: <eth1> --  NIC for the provisioning interface on the undercloud host
-- virthost_provisioning_ip: <192.168.122.1> -- IP address for the provisioning interface on the undercloud host
-- virthost_provisioning_netmask: <255.255.255.192> -- Netmask for the provisioning interface on the undercloud host
 - virthost_provisioning_hwaddr: <52:54:00:00:76:00> -- MAC address the provisioning interface on the undercloud host
 - working_dir: <'/home/stack'> -- working directory for the role.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,5 @@
 ---
 # defaults file for ansible-role-tripleo-baremetal-prep-virthost
 virthost_provisioning_interface: eth1
-virthost_provisioning_ip: 192.168.122.1
-virthost_provisioning_netmask: 255.255.255.192
 virthost_provisioning_hwaddr: 52:54:00:00:76:00
 working_dir: /home/stack

--- a/templates/add-provisioning-interface.sh.j2
+++ b/templates/add-provisioning-interface.sh.j2
@@ -18,8 +18,6 @@ set -eux
 
 sudo cat > /etc/sysconfig/network-scripts/ifcfg-{{ virthost_provisioning_interface }} << EOF
 NAME={{ virthost_provisioning_interface }}
-IPADDR={{ virthost_provisioning_ip }}
-NETMASK={{ virthost_provisioning_netmask }}
 NM_CONTROLLED=no
 DEFROUTE=yes
 IPV4_FAILURE_FATAL=no

--- a/templates/ifcfg-virthost-provision.j2
+++ b/templates/ifcfg-virthost-provision.j2
@@ -1,6 +1,4 @@
 NAME={{ virthost_provisioning_interface }}
-IPADDR={{ virthost_provisioning_ip }}
-NETMASK={{ virthost_provisioning_netmask }}
 NM_CONTROLLED=no
 DEFROUTE=yes
 IPV4_FAILURE_FATAL=no


### PR DESCRIPTION
I guess it is better to give bridge an IP address, then it could be used to connect virthost to provisioning network. I was testing a overcloud with both baremetal and VM nodes, but for undercloud to connect to virthost's hypervisor using Ironic's pxe_ssh driver, the virthost should be connected to provisioning network. Correct me if I am wrong. 
Thanks
